### PR TITLE
If the input field is empty, do not create a new message

### DIFF
--- a/chatty.js
+++ b/chatty.js
@@ -69,9 +69,10 @@ function toggleClass(checkbox) {
 function createMessage(e) {
   if (e.key === "Enter") {
     var userMessage = userInput.value;
-    addMessage(userMessage)
-    userInput.value = "";
-
+    if (userMessage !== "") {
+      addMessage(userMessage)
+      userInput.value = "";
+    }
   }
 }
 


### PR DESCRIPTION
Added conditional to the create message function.  If the message is an empty string/the input field is empty when the enter key is pressed, the message will not be created